### PR TITLE
docs(A9-462): correct the boost and decimation article against the engine

### DIFF
--- a/Common_Settings/Overview.md
+++ b/Common_Settings/Overview.md
@@ -30,7 +30,7 @@ This section includes articles about features shared by most of the charts and m
 
 * [ASYNC Rendering](ASYNC_Rendering)
 * [Server-Side Rendering](Server-Side_Rendering)
-* [Performance: Boost and Decimation](Performance_Boost)
+* [Performance Boost](Performance_Boost)
 
 ## Export
 

--- a/Common_Settings/Overview.md
+++ b/Common_Settings/Overview.md
@@ -30,6 +30,7 @@ This section includes articles about features shared by most of the charts and m
 
 * [ASYNC Rendering](ASYNC_Rendering)
 * [Server-Side Rendering](Server-Side_Rendering)
+* [Performance: Boost and Decimation](Performance_Boost)
 
 ## Export
 

--- a/Common_Settings/Performance_Boost.md
+++ b/Common_Settings/Performance_Boost.md
@@ -1,68 +1,70 @@
-# Performance: Boost and Decimation
+# Performance Boost
 
 ## Overview
 
 Large datasets make a chart slow in two different ways, and AnyChart answers each with its own mechanism.
 
-**Decimation** reduces how many points are *drawn*. The data stays intact — the chart selects a representative subset and renders that, so an 80,000-point line still looks like the same line but costs a fraction of the DOM.
+**Decimation** reduces how many points are *drawn*. The data stays intact - the chart selects a representative subset and renders that, so an 80,000-point line still looks like the same line but costs a fraction of the DOM.
 
 **Boost** changes *how* points are drawn. Instead of one SVG element per point, the series is rasterised onto a single Canvas (or WebGL) layer, which removes the per-element cost entirely.
 
-The two are independent and can be tuned separately. Decimation is applied by default; boost engages automatically only past a threshold.
+The two are configured separately, but they are not independent at runtime: when boost is drawing a series, decimation is skipped for it, because boost renders every point cheaply and there is nothing to gain.
 
-Both are configured with four settings, available on the chart and on individual series:
+Both are controlled by four settings, available on the chart and on individual series:
 
-* {api:anychart.core.ChartWithOrthogonalScales#maxPointsRendered}maxPointsRendered(){api}
-* {api:anychart.core.ChartWithOrthogonalScales#decimationAlgorithm}decimationAlgorithm(){api}
-* {api:anychart.core.ChartWithOrthogonalScales#boostThreshold}boostThreshold(){api}
-* {api:anychart.core.ChartWithOrthogonalScales#boostEnabled}boostEnabled(){api}
+* {api:?entry=maxPointsRendered}maxPointsRendered(){api}
+* {api:?entry=decimationAlgorithm}decimationAlgorithm(){api}
+* {api:?entry=boostThreshold}boostThreshold(){api}
+* {api:?entry=boostEnabled}boostEnabled(){api}
 
 ## Supported Chart Types
 
-These settings live on `anychart.core.ChartWithOrthogonalScales`, so they are available on every chart type built on orthogonal scales: Cartesian charts (line, area, column, bar, spline, step line, marker, and so on), Scatter, Radar, and Polar.
+The settings are defined on the chart base that owns orthogonal scales, so they are available on:
 
-They have no effect on charts without orthogonal scales — Pie, Treemap, Sankey, gauges and similar types ignore them.
+* all Cartesian charts - line, area, column, bar, spline, step line, marker and the rest
+* [Cartesian 3D](../Basic_Charts/3D/Overview), [Heat Map](../Basic_Charts/Heat_Map_Chart), [Pareto](../Basic_Charts/Pareto_Chart), [Waterfall](../Basic_Charts/Waterfall_Chart) and [Mekko](../Basic_Charts/Mekko_Chart), which are built on the same base
+* [Scatter](../Basic_Charts/Scatter_Plot/Overview), [Radar](../Basic_Charts/Radar_Chart) and [Polar](../Basic_Charts/Polar_Chart)
+
+[Stock](../Stock_Charts/Overview) series are built on the same series base, so the four settings work at series level there too, and the default 1500-point decimation applies.
+
+[Gantt](../Gantt_Chart/Overview) has its own `boostEnabled()` and `boostThreshold()` with different meaning: they count visible rows rather than data points, and the threshold defaults to 500.
+
+Charts without orthogonal scales - Pie, Treemap, Sankey, gauges and similar types - do not have these methods at all. Calling them there raises a TypeError rather than being ignored.
 
 ## Decimation
 
-Decimation runs when a series has more points than `maxPointsRendered`.
+Decimation runs when a series has more points than `maxPointsRendered()`, which defaults to 1500.
 
 ```
-var chart = anychart.line(bigDataset);
-
-// draw at most 2000 points per series (default: 1500)
+// draw at most 2000 points per series
 chart.maxPointsRendered(2000);
-
-chart.container('container');
-chart.draw();
 ```
+
+Setting it to `0` turns decimation off for the chart.
 
 ### Algorithms
 
 `decimationAlgorithm()` accepts three values:
 
-* `"auto"` — the default. Picks the algorithm from the series shape: `"min-max"` for discrete series (column, bar, and other types that draw one mark per point), `"lttb"` for continuous ones (line, area, spline).
-* `"lttb"` — Largest Triangle Three Buckets. Preserves the visual *shape* of a curve, keeping the points that contribute most to its silhouette. The right choice for line-like series.
-* `"min-max"` — keeps the minimum and maximum Y of each bucket. Preserves the *envelope*, so spikes are never lost. The right choice when outliers matter.
+* `"auto"` - the default. Picks the algorithm from the series shape: `"min-max"` for discrete series, the ones whose drawer marks each point separately, and `"lttb"` for continuous ones such as line, area and spline.
+* `"lttb"` - Largest Triangle Three Buckets. Preserves the visual *shape* of a curve, keeping the points that contribute most to its silhouette. The right choice for line-like series.
+* `"min-max"` - keeps the minimum and maximum Y of each bucket. Preserves the *envelope*, so spikes are never lost. The right choice when outliers matter.
 
 ```
-var chart = anychart.line(bigDataset);
-
 chart.maxPointsRendered(2000);
-chart.decimationAlgorithm('lttb');
-
-chart.container('container');
-chart.draw();
+chart.decimationAlgorithm("lttb");
 ```
+
+The value is a plain string, not an enum: an unrecognised one is not rejected, it falls through to `"min-max"`.
 
 ### When Decimation Is Skipped
 
 Decimation is deliberately not applied when dropping points would change what the chart means:
 
-* **Stacked series** — removing a point from one series would break the stack alignment of the others.
-* **Bubble and other size-encoded series** — every point is an independent mark whose size carries data. Subset selection built for line envelopes visibly removes bubbles and shrinks the cloud, so it is not lossless here.
-* **Series that boost will render anyway** — boost draws all points cheaply, so there is nothing to gain.
-* **Series already under the limit** — no work is done when the point count is at or below `maxPointsRendered`.
+* **Stacked series** - removing a point from one series would break the stack alignment of the others.
+* **Bubble and other size-encoded series** - every point is an independent mark whose size carries data, so subset selection built for line envelopes visibly removes bubbles and shrinks the cloud.
+* **Series that boost will render anyway** - boost draws all points cheaply, so there is nothing to gain.
+* **Series at or below the limit**, and any series when `maxPointsRendered()` is `0`.
 
 ## Boost
 
@@ -71,13 +73,8 @@ Boost rasterises a series onto a Canvas layer instead of building SVG elements.
 By default `boostEnabled()` is `null`, meaning *automatic*: boost engages once a series exceeds `boostThreshold()`, which defaults to 5000 points.
 
 ```
-var chart = anychart.line(hugeDataset);
-
 // engage boost above 10000 points instead of the default 5000
 chart.boostThreshold(10000);
-
-chart.container('container');
-chart.draw();
 ```
 
 Set `boostEnabled()` explicitly to force the decision:
@@ -92,25 +89,28 @@ chart.boostEnabled(false);
 
 ### When Boost Is Skipped
 
-In automatic mode boost is not used for:
+Some conditions are checked before `boostEnabled(true)` is honoured, so they apply in **every** mode:
 
 * **Stacked series** and **3D series**.
-* **OHLC and range-based series** (range area, range column, and similar) — their marks are composite shapes.
-* **Plots with more than one enabled series.** The boost canvas is composited above the SVG stage, so in a multi-series plot it would cover the SVG-rendered siblings and silently change their visible order. Automatic boost therefore only applies when the series is the only enabled one in its plot.
+* **OHLC and range-based series** - range area, range column and similar - because their marks are composite shapes.
+* **Series whose drawer boost cannot render.** Boost draws line, step line, spline, area, bubble, marker and column shapes; anything else falls back to SVG.
 * **Environments without Canvas or WebGL.**
 
-Setting `boostEnabled(true)` bypasses both the threshold and the single-series rule. Use it when you have measured the trade-off and accept that a boosted series is drawn above its SVG siblings.
+Two more conditions apply only in automatic mode, and `boostEnabled(true)` bypasses both:
+
+* **The point count is at or below `boostThreshold()`**, or the threshold is `0`.
+* **The plot has more than one enabled series.** The boost canvas is composited above the SVG stage, so in a multi-series plot it would cover the SVG-rendered siblings and silently change their visible order.
+
+Forcing boost on a multi-series plot is supported, as long as you accept that the boosted series is drawn above its SVG siblings.
 
 ## WebGL Renderer
 
-Canvas boost ships in the main bundle and needs nothing extra. A WebGL renderer is available as a separate opt-in module for the heaviest datasets:
+Canvas boost ships in the main bundle and needs nothing extra. A WebGL renderer is available as a separate opt-in module for the heaviest datasets. It can be added with a script tag like any other module, or loaded on demand:
 
 ```
-// load on demand; boost falls back to Canvas until this resolves
-anychart.loadModule('boost-webgl').then(function () {
-  var chart = anychart.line(hugeDataset);
+// returns a promise; boost falls back to Canvas until it resolves
+anychart.loadModule("boost-webgl").then(function () {
   chart.boostEnabled(true);
-  chart.container('container');
   chart.draw();
 });
 ```
@@ -118,35 +118,55 @@ anychart.loadModule('boost-webgl').then(function () {
 You can also warm it up ahead of time without waiting on the result:
 
 ```
-anychart.preload('boost-webgl');
+anychart.preload("boost-webgl");
 ```
 
-When the module is not loaded, boost uses Canvas — nothing breaks and no configuration changes are needed.
+When the module is not loaded, boost uses Canvas - nothing breaks and no configuration changes are needed.
 
 ## Chart-Level and Series-Level Settings
 
 All four settings exist on both the chart and the individual series. A series resolves each setting from its own value first, then the chart's, then the built-in default:
 
 ```
-var chart = anychart.line();
-
 // chart-wide policy
 chart.maxPointsRendered(2000);
 chart.boostThreshold(10000);
 
-var detail = chart.line(detailData);
 // this one series keeps every point it has
+var detail = chart.line(detailData);
 detail.maxPointsRendered(50000);
-
-chart.container('container');
-chart.draw();
 ```
+
+Note that the built-in defaults below are what the engine *behaves* like, not necessarily what the getter returns. On Cartesian charts they come from the theme, so `chart.boostThreshold()` reads back 5000. On Scatter, Radar and Polar they are applied by the series as a fallback, so the getter returns `undefined` until the setting is assigned.
 
 ## Defaults
 
-| Setting | Default | Meaning |
-|---|---|---|
-| `maxPointsRendered()` | `1500` | Decimation starts above this many points per series |
-| `decimationAlgorithm()` | `"auto"` | `"min-max"` for discrete series, `"lttb"` for continuous |
-| `boostThreshold()` | `5000` | Automatic boost starts above this many points per series |
-| `boostEnabled()` | `null` | Automatic — decided by `boostThreshold()` and the rules above |
+<table>
+<tbody>
+<tr>
+<th width='220'>Name</th>
+<th width='120'>Default</th>
+<th>Description</th>
+</tr>
+<tr>
+<td>maxPointsRendered()</td>
+<td>1500</td>
+<td>Decimation starts above this many points per series; 0 disables it</td>
+</tr>
+<tr>
+<td>decimationAlgorithm()</td>
+<td>"auto"</td>
+<td>"min-max" for discrete series, "lttb" for continuous ones</td>
+</tr>
+<tr>
+<td>boostThreshold()</td>
+<td>5000</td>
+<td>Automatic boost starts above this many points per series</td>
+</tr>
+<tr>
+<td>boostEnabled()</td>
+<td>null</td>
+<td>Automatic - decided by boostThreshold() and the rules above</td>
+</tr>
+</tbody>
+</table>

--- a/Common_Settings/Performance_Boost.md
+++ b/Common_Settings/Performance_Boost.md
@@ -22,8 +22,8 @@ Both are controlled by four settings, available on the chart and on individual s
 The settings are defined on the chart base that owns orthogonal scales, so they are available on:
 
 * all Cartesian charts - line, area, column, bar, spline, step line, marker and the rest
-* [Cartesian 3D](../Basic_Charts/3D/Overview), [Heat Map](../Basic_Charts/Heat_Map_Chart), [Pareto](../Basic_Charts/Pareto_Chart), [Waterfall](../Basic_Charts/Waterfall_Chart) and [Mekko](../Basic_Charts/Mekko_Chart), which are built on the same base
-* [Scatter](../Basic_Charts/Scatter_Plot/Overview), [Radar](../Basic_Charts/Radar_Chart) and [Polar](../Basic_Charts/Polar_Chart)
+* [Cartesian 3D](../Basic_Charts/3D/Overview), [Heat Map](../Basic_Charts/Heat_Map_Chart), [Pareto](../Basic_Charts/Pareto_Chart), [Waterfall](../Basic_Charts/Waterfall_Chart) and [Mekko](../Basic_Charts/Marimekko_Chart/Mekko_Chart), which are built on the same base
+* [Scatter](../Basic_Charts/Scatter_Plot/Overview), [Radar](../Basic_Charts/Radar_Plot/Overview) and [Polar](../Basic_Charts/Polar_Plot/Overview)
 
 [Stock](../Stock_Charts/Overview) series are built on the same series base, so the four settings work at series level there too, and the default 1500-point decimation applies.
 
@@ -57,7 +57,7 @@ chart.decimationAlgorithm("lttb");
 
 The value is a plain string, not an enum: an unrecognised one is not rejected, it falls through to `"min-max"`.
 
-This sample feeds 20000 points to a line chart and draws 2000 of them. Switch the algorithm in the code to see the difference between preserving the shape and preserving the envelope:
+This sample feeds 20000 points to a line chart and draws 2000 of them. It also switches boost off, because 20000 points is past the 5000-point boost threshold and a boosted series is never decimated. Switch the algorithm in the code to see the difference between preserving the shape and preserving the envelope:
 
 {sample}CS\_Boost\_01{sample}
 
@@ -107,13 +107,13 @@ Two more conditions apply only in automatic mode, and `boostEnabled(true)` bypas
 
 Forcing boost on a multi-series plot is supported, as long as you accept that the boosted series is drawn above its SVG siblings.
 
-This sample draws 40000 points on a single Canvas layer. Set `boostEnabled(false)` in the code to render the same data as SVG and compare:
+This sample draws 40000 points on a single Canvas layer. Set `boostEnabled(false)` in the code to compare. The series then falls back to SVG, and decimation - no longer pre-empted by boost - trims it to the default 1500 points.
 
 {sample}CS\_Boost\_02{sample}
 
 ## WebGL Renderer
 
-Canvas boost ships in the main bundle and needs nothing extra. A WebGL renderer is available as a separate opt-in module for the heaviest datasets. It can be added with a script tag like any other module, or loaded on demand:
+Canvas boost ships in the main bundle and needs nothing extra. A WebGL renderer is available as a separate opt-in module for the heaviest datasets, `anychart-boost-webgl.min.js`. It can be added with a script tag like any other [module](../Quick_Start/Modules#boost_webgl_renderer), or loaded on demand:
 
 ```
 // returns a promise; boost falls back to Canvas until it resolves

--- a/Common_Settings/Performance_Boost.md
+++ b/Common_Settings/Performance_Boost.md
@@ -131,7 +131,7 @@ The Canvas renderer has a small repertoire of shapes. Three families come out th
 
 **Heat Map and Box** series fail harder still: the renderer accepts them, paints nothing, and does not hand them back to SVG, so the chart comes out empty for as long as boost is engaged. A heat map with more than 5000 cells falls into this by default too, so switch boost off there as well.
 
-This sample draws 40000 markers on a single Canvas layer - a marker series is one of the shapes the renderer draws faithfully. Set `boostEnabled(false)` in the code to compare: the series falls back to SVG, and decimation - no longer pre-empted by boost - trims it to the default 1500 points:
+This sample draws 10000 markers on a single Canvas layer - a marker series is one of the shapes the renderer draws faithfully. Set `boostEnabled(false)` in the code to compare: the series falls back to SVG, and decimation - no longer pre-empted by boost - trims it to the default 1500 points:
 
 {sample}CS\_Boost\_02{sample}
 

--- a/Common_Settings/Performance_Boost.md
+++ b/Common_Settings/Performance_Boost.md
@@ -57,6 +57,10 @@ chart.decimationAlgorithm("lttb");
 
 The value is a plain string, not an enum: an unrecognised one is not rejected, it falls through to `"min-max"`.
 
+This sample feeds 20000 points to a line chart and draws 2000 of them. Switch the algorithm in the code to see the difference between preserving the shape and preserving the envelope:
+
+{sample}CS\_Boost\_01{sample}
+
 ### When Decimation Is Skipped
 
 Decimation is deliberately not applied when dropping points would change what the chart means:
@@ -102,6 +106,10 @@ Two more conditions apply only in automatic mode, and `boostEnabled(true)` bypas
 * **The plot has more than one enabled series.** The boost canvas is composited above the SVG stage, so in a multi-series plot it would cover the SVG-rendered siblings and silently change their visible order.
 
 Forcing boost on a multi-series plot is supported, as long as you accept that the boosted series is drawn above its SVG siblings.
+
+This sample draws 40000 points on a single Canvas layer. Set `boostEnabled(false)` in the code to render the same data as SVG and compare:
+
+{sample}CS\_Boost\_02{sample}
 
 ## WebGL Renderer
 

--- a/Common_Settings/Performance_Boost.md
+++ b/Common_Settings/Performance_Boost.md
@@ -6,9 +6,9 @@ Large datasets make a chart slow in two different ways, and AnyChart answers eac
 
 **Decimation** reduces how many points are *drawn*. The data stays intact - the chart selects a representative subset and renders that, so an 80,000-point line still looks like the same line but costs a fraction of the DOM.
 
-**Boost** changes *how* points are drawn. Instead of one SVG element per point, the series is rasterised onto a single Canvas (or WebGL) layer, which removes the per-element cost entirely.
+**Boost** changes *how* points are drawn. Instead of one SVG element per point, the series is rasterized onto a single Canvas (or WebGL) layer, which removes the per-element cost entirely.
 
-The two are configured separately, but they are not independent at runtime: when boost is drawing a series, decimation is skipped for it, because boost renders every point cheaply and there is nothing to gain.
+The two are configured separately, but they are not independent at runtime: as soon as boost engages for a series, decimation is skipped for it, because boost is meant to render every point cheaply and there would be nothing to gain. The two never combine. Which series boost can actually render is a separate question - see [What Boost Draws](#what_boost_draws).
 
 Both are controlled by four settings, available on the chart and on individual series:
 
@@ -22,10 +22,17 @@ Both are controlled by four settings, available on the chart and on individual s
 The settings are defined on the chart base that owns orthogonal scales, so they are available on:
 
 * all Cartesian charts - line, area, column, bar, spline, step line, marker and the rest
-* [Cartesian 3D](../Basic_Charts/3D/Overview), [Heat Map](../Basic_Charts/Heat_Map_Chart), [Pareto](../Basic_Charts/Pareto_Chart), [Waterfall](../Basic_Charts/Waterfall_Chart) and [Mekko](../Basic_Charts/Marimekko_Chart/Mekko_Chart), which are built on the same base
+* [Cartesian 3D](../Basic_Charts/3D/Overview), [Heat Map](../Basic_Charts/Heat_Map_Chart), [Pareto](../Basic_Charts/Pareto_Chart), [Waterfall](../Basic_Charts/Waterfall_Chart), [Mekko](../Basic_Charts/Marimekko_Chart/Mekko_Chart) and [Stream Graph](../Basic_Charts/Stream_Graph), which are built on the same base
 * [Scatter](../Basic_Charts/Scatter_Plot/Overview), [Radar](../Basic_Charts/Radar_Plot/Overview) and [Polar](../Basic_Charts/Polar_Plot/Overview)
 
-[Stock](../Stock_Charts/Overview) series are built on the same series base, so the four settings work at series level there too, and the default 1500-point decimation applies.
+Having the methods is not the same as having an effect. Both mechanisms give up on stacked series, and three of those chart types stack by default:
+
+* [Waterfall](../Basic_Charts/Waterfall_Chart) and [Stream Graph](../Basic_Charts/Stream_Graph) stack unconditionally - stacking is what those chart types *are* - so the four settings are accepted and then never change anything.
+* [Mekko](../Basic_Charts/Marimekko_Chart/Mekko_Chart), Mosaic and Barmekko stack through their theme, so boost and decimation engage only if you turn stacking off with `chart.yScale().stackMode("none")`.
+
+[Cartesian 3D](../Basic_Charts/3D/Overview) has a different limit: its series are never boosted, whatever `boostEnabled()` says. Decimation still applies there.
+
+On [Stock](../Stock_Charts/Overview) the four methods exist on the series - not on the chart or the plot - but only `boostEnabled(true)` does anything. Decimation and the automatic boost threshold both need the Cartesian drawing plan, which stock series do not build, so `maxPointsRendered()`, `decimationAlgorithm()` and `boostThreshold()` are accepted and ignored, and the 1500-point default never applies. Stock does not need decimation anyway: it thins large series itself through [data grouping](../Stock_Charts/Data_Grouping).
 
 [Gantt](../Gantt_Chart/Overview) has its own `boostEnabled()` and `boostThreshold()` with different meaning: they count visible rows rather than data points, and the threshold defaults to 500.
 
@@ -55,24 +62,26 @@ chart.maxPointsRendered(2000);
 chart.decimationAlgorithm("lttb");
 ```
 
-The value is a plain string, not an enum: an unrecognised one is not rejected, it falls through to `"min-max"`.
+The value is a plain string, not an enum: an unrecognized one is not rejected, it falls through to `"min-max"`.
 
 This sample feeds 20000 points to a line chart and draws 2000 of them. It also switches boost off, because 20000 points is past the 5000-point boost threshold and a boosted series is never decimated. Switch the algorithm in the code to see the difference between preserving the shape and preserving the envelope:
 
 {sample}CS\_Boost\_01{sample}
 
-### When Decimation Is Skipped
+### When Decimation is Skipped
 
 Decimation is deliberately not applied when dropping points would change what the chart means:
 
 * **Stacked series** - removing a point from one series would break the stack alignment of the others.
 * **Bubble and other size-encoded series** - every point is an independent mark whose size carries data, so subset selection built for line envelopes visibly removes bubbles and shrinks the cloud.
-* **Series that boost will render anyway** - boost draws all points cheaply, so there is nothing to gain.
+* **Series that boost has engaged for** - boost is supposed to draw all points cheaply, so there is nothing to gain.
 * **Series at or below the limit**, and any series when `maxPointsRendered()` is `0`.
+
+The third rule is worth reading carefully: decimation is dropped the moment boost *engages*, which is decided before anything is drawn and without looking at whether the Canvas renderer knows the series shape. On an area series, where it does not, you get the worst of both - see [What Boost Draws](#what_boost_draws).
 
 ## Boost
 
-Boost rasterises a series onto a Canvas layer instead of building SVG elements.
+Boost rasterizes a series onto a Canvas layer instead of building SVG elements.
 
 By default `boostEnabled()` is `null`, meaning *automatic*: boost engages once a series exceeds `boostThreshold()`, which defaults to 5000 points.
 
@@ -91,13 +100,12 @@ chart.boostEnabled(true);
 chart.boostEnabled(false);
 ```
 
-### When Boost Is Skipped
+### When Boost is Skipped
 
-Some conditions are checked before `boostEnabled(true)` is honoured, so they apply in **every** mode:
+These conditions are checked up front, before anything is drawn and before `boostEnabled(true)` is honored, so they apply in **every** mode:
 
 * **Stacked series** and **3D series**.
-* **OHLC and range-based series** - range area, range column and similar - because their marks are composite shapes.
-* **Series whose drawer boost cannot render.** Boost draws line, step line, spline, area, bubble, marker and column shapes; anything else falls back to SVG.
+* **OHLC and range-based series** - range area, range column, range stick, dumbbell and similar - because their marks are composite shapes.
 * **Environments without Canvas or WebGL.**
 
 Two more conditions apply only in automatic mode, and `boostEnabled(true)` bypasses both:
@@ -107,7 +115,23 @@ Two more conditions apply only in automatic mode, and `boostEnabled(true)` bypas
 
 Forcing boost on a multi-series plot is supported, as long as you accept that the boosted series is drawn above its SVG siblings.
 
-This sample draws 40000 points on a single Canvas layer. Set `boostEnabled(false)` in the code to compare. The series then falls back to SVG, and decimation - no longer pre-empted by boost - trims it to the default 1500 points.
+The series *shape* is on neither list. Whether the Canvas renderer can draw the series at all is settled last, after the canvas has been attached and after decimation has already been dropped - which is what the next section is about.
+
+### What Boost Draws
+
+The Canvas renderer has a small repertoire of shapes. Three families come out the way you would expect:
+
+* **column and bar** series
+* **marker** series
+* **bubble** series
+
+**Line-shaped series** - line, spline, step line, jump line and stick - are boosted too, but the Canvas renderer fills them down to the zero line rather than stroking the outline, so a boosted line reads as an area. Keep `boostEnabled(false)` on them when the outline is the point.
+
+**Area-shaped series** - area, spline area and step area - are not drawn by the renderer at all. Boost still engages: the canvas is attached, decimation is skipped for the series, the renderer then finds no shape it knows and hands the series back to SVG, which draws every point. A 20000-point area chart therefore renders 20000 SVG vertices with boost on and 1500 with `boostEnabled(false)` - boost does not merely fail to help an area chart, it makes it slower. Because the default `boostEnabled()` is *automatic*, a single-series area chart above 5000 points reaches that state on its own; set `boostEnabled(false)` there.
+
+**Heat Map and Box** series fail harder still: the renderer accepts them, paints nothing, and does not hand them back to SVG, so the chart comes out empty for as long as boost is engaged. A heat map with more than 5000 cells falls into this by default too, so switch boost off there as well.
+
+This sample draws 40000 markers on a single Canvas layer - a marker series is one of the shapes the renderer draws faithfully. Set `boostEnabled(false)` in the code to compare: the series falls back to SVG, and decimation - no longer pre-empted by boost - trims it to the default 1500 points:
 
 {sample}CS\_Boost\_02{sample}
 
@@ -152,8 +176,8 @@ Note that the built-in defaults below are what the engine *behaves* like, not ne
 <table>
 <tbody>
 <tr>
-<th width='220'>Name</th>
-<th width='120'>Default</th>
+<th width="220">Name</th>
+<th width="120">Default</th>
 <th>Description</th>
 </tr>
 <tr>

--- a/Common_Settings/Performance_Boost.md
+++ b/Common_Settings/Performance_Boost.md
@@ -1,0 +1,152 @@
+# Performance: Boost and Decimation
+
+## Overview
+
+Large datasets make a chart slow in two different ways, and AnyChart answers each with its own mechanism.
+
+**Decimation** reduces how many points are *drawn*. The data stays intact — the chart selects a representative subset and renders that, so an 80,000-point line still looks like the same line but costs a fraction of the DOM.
+
+**Boost** changes *how* points are drawn. Instead of one SVG element per point, the series is rasterised onto a single Canvas (or WebGL) layer, which removes the per-element cost entirely.
+
+The two are independent and can be tuned separately. Decimation is applied by default; boost engages automatically only past a threshold.
+
+Both are configured with four settings, available on the chart and on individual series:
+
+* {api:anychart.core.ChartWithOrthogonalScales#maxPointsRendered}maxPointsRendered(){api}
+* {api:anychart.core.ChartWithOrthogonalScales#decimationAlgorithm}decimationAlgorithm(){api}
+* {api:anychart.core.ChartWithOrthogonalScales#boostThreshold}boostThreshold(){api}
+* {api:anychart.core.ChartWithOrthogonalScales#boostEnabled}boostEnabled(){api}
+
+## Supported Chart Types
+
+These settings live on `anychart.core.ChartWithOrthogonalScales`, so they are available on every chart type built on orthogonal scales: Cartesian charts (line, area, column, bar, spline, step line, marker, and so on), Scatter, Radar, and Polar.
+
+They have no effect on charts without orthogonal scales — Pie, Treemap, Sankey, gauges and similar types ignore them.
+
+## Decimation
+
+Decimation runs when a series has more points than `maxPointsRendered`.
+
+```
+var chart = anychart.line(bigDataset);
+
+// draw at most 2000 points per series (default: 1500)
+chart.maxPointsRendered(2000);
+
+chart.container('container');
+chart.draw();
+```
+
+### Algorithms
+
+`decimationAlgorithm()` accepts three values:
+
+* `"auto"` — the default. Picks the algorithm from the series shape: `"min-max"` for discrete series (column, bar, and other types that draw one mark per point), `"lttb"` for continuous ones (line, area, spline).
+* `"lttb"` — Largest Triangle Three Buckets. Preserves the visual *shape* of a curve, keeping the points that contribute most to its silhouette. The right choice for line-like series.
+* `"min-max"` — keeps the minimum and maximum Y of each bucket. Preserves the *envelope*, so spikes are never lost. The right choice when outliers matter.
+
+```
+var chart = anychart.line(bigDataset);
+
+chart.maxPointsRendered(2000);
+chart.decimationAlgorithm('lttb');
+
+chart.container('container');
+chart.draw();
+```
+
+### When Decimation Is Skipped
+
+Decimation is deliberately not applied when dropping points would change what the chart means:
+
+* **Stacked series** — removing a point from one series would break the stack alignment of the others.
+* **Bubble and other size-encoded series** — every point is an independent mark whose size carries data. Subset selection built for line envelopes visibly removes bubbles and shrinks the cloud, so it is not lossless here.
+* **Series that boost will render anyway** — boost draws all points cheaply, so there is nothing to gain.
+* **Series already under the limit** — no work is done when the point count is at or below `maxPointsRendered`.
+
+## Boost
+
+Boost rasterises a series onto a Canvas layer instead of building SVG elements.
+
+By default `boostEnabled()` is `null`, meaning *automatic*: boost engages once a series exceeds `boostThreshold()`, which defaults to 5000 points.
+
+```
+var chart = anychart.line(hugeDataset);
+
+// engage boost above 10000 points instead of the default 5000
+chart.boostThreshold(10000);
+
+chart.container('container');
+chart.draw();
+```
+
+Set `boostEnabled()` explicitly to force the decision:
+
+```
+// always boost, regardless of point count
+chart.boostEnabled(true);
+
+// never boost
+chart.boostEnabled(false);
+```
+
+### When Boost Is Skipped
+
+In automatic mode boost is not used for:
+
+* **Stacked series** and **3D series**.
+* **OHLC and range-based series** (range area, range column, and similar) — their marks are composite shapes.
+* **Plots with more than one enabled series.** The boost canvas is composited above the SVG stage, so in a multi-series plot it would cover the SVG-rendered siblings and silently change their visible order. Automatic boost therefore only applies when the series is the only enabled one in its plot.
+* **Environments without Canvas or WebGL.**
+
+Setting `boostEnabled(true)` bypasses both the threshold and the single-series rule. Use it when you have measured the trade-off and accept that a boosted series is drawn above its SVG siblings.
+
+## WebGL Renderer
+
+Canvas boost ships in the main bundle and needs nothing extra. A WebGL renderer is available as a separate opt-in module for the heaviest datasets:
+
+```
+// load on demand; boost falls back to Canvas until this resolves
+anychart.loadModule('boost-webgl').then(function () {
+  var chart = anychart.line(hugeDataset);
+  chart.boostEnabled(true);
+  chart.container('container');
+  chart.draw();
+});
+```
+
+You can also warm it up ahead of time without waiting on the result:
+
+```
+anychart.preload('boost-webgl');
+```
+
+When the module is not loaded, boost uses Canvas — nothing breaks and no configuration changes are needed.
+
+## Chart-Level and Series-Level Settings
+
+All four settings exist on both the chart and the individual series. A series resolves each setting from its own value first, then the chart's, then the built-in default:
+
+```
+var chart = anychart.line();
+
+// chart-wide policy
+chart.maxPointsRendered(2000);
+chart.boostThreshold(10000);
+
+var detail = chart.line(detailData);
+// this one series keeps every point it has
+detail.maxPointsRendered(50000);
+
+chart.container('container');
+chart.draw();
+```
+
+## Defaults
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `maxPointsRendered()` | `1500` | Decimation starts above this many points per series |
+| `decimationAlgorithm()` | `"auto"` | `"min-max"` for discrete series, `"lttb"` for continuous |
+| `boostThreshold()` | `5000` | Automatic boost starts above this many points per series |
+| `boostEnabled()` | `null` | Automatic — decided by `boostThreshold()` and the rules above |

--- a/Quick_Start/Modules.md
+++ b/Quick_Start/Modules.md
@@ -478,13 +478,13 @@ The UI Binding module is a set of utilities for binding HTML5 UI elements to cha
 
 ### Boost WebGL Renderer
 
-A module that enables the WebGL renderer for [Performance Boost](../Common_Settings/Performance_Boost). Canvas-based boost is part of the main bundle and needs no extra module; this one is only for the heaviest datasets.
+A module that enables the WebGL renderer for [Performance Boost](../Common_Settings/Performance_Boost). Canvas-based boost is part of the main bundle and needs no extra module; this one is only for the heaviest datasets. The module is new in AnyChart 9 - the file is not published under an 8.x release path, so the script tag below only resolves against a 9.x release:
 
 ```
 <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-boost-webgl.min.js"></script>
 ```
 
-It can also be loaded on demand, in which case boost falls back to Canvas until it resolves:
+It can also be loaded on demand, in which case boost falls back to Canvas until it resolves. `loadModule()` takes the release path from the AnyChart script tag already on the page, so it never needs a version of its own:
 
 ```
 anychart.loadModule("boost-webgl");

--- a/Quick_Start/Modules.md
+++ b/Quick_Start/Modules.md
@@ -128,6 +128,14 @@ A module for creating [Cartesian 3D](../Basic_Charts/3D/Overview) charts (except
 <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-cartesian-3d.min.js"></script>
 ```
 
+### Boost (WebGL)
+
+An optional WebGL renderer for [Boost](../Common_Settings/Performance_Boost). Canvas-based boost is already part of the main bundle and needs no extra module; this one is only for the heaviest datasets. Unlike the modules above it is not added with a script tag — it is loaded on demand, and boost falls back to Canvas until it resolves:
+
+```
+anychart.loadModule('boost-webgl');
+```
+
 ### Calendar
 
 A module for creating [Calendar](../Basic_Charts/Calendar_Chart) charts:

--- a/Quick_Start/Modules.md
+++ b/Quick_Start/Modules.md
@@ -50,7 +50,7 @@ For example, to create an exportable Pie chart, combine Core with the [Pie and D
 
 The same logic applies to the **Base** module. However, please note that it already includes some chart types, so you have to reference other modules only if you need to add a chart type that is not included or a feature.
 
-As for **Bundle**, it includes all other modules except [Extensions](#extensions) and [Data Sheet](#data_sheet). Add the Data Sheet module yourself when you need it.
+As for **Bundle**, it includes all other modules except [Extensions](#extensions), [Data Sheet](#data_sheet) and the [Boost WebGL Renderer](#boost_webgl_renderer). Add those yourself when you need them.
 
 ## Builder
 
@@ -128,14 +128,6 @@ A module for creating [Cartesian 3D](../Basic_Charts/3D/Overview) charts (except
 <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-cartesian-3d.min.js"></script>
 ```
 
-### Boost (WebGL)
-
-An optional WebGL renderer for [Boost](../Common_Settings/Performance_Boost). Canvas-based boost is already part of the main bundle and needs no extra module; this one is only for the heaviest datasets. Unlike the modules above it is not added with a script tag — it is loaded on demand, and boost falls back to Canvas until it resolves:
-
-```
-anychart.loadModule('boost-webgl');
-```
-
 ### Calendar
 
 A module for creating [Calendar](../Basic_Charts/Calendar_Chart) charts:
@@ -162,7 +154,7 @@ A module for creating [Circular Gauges](../Gauges/Circular_Gauge):
 
 ### Data Sheet
 
-A module for creating a [Data Sheet](../Data_Sheet/Overview) — an interactive data grid. Unlike the other modules, it is not a part of **Bundle**, so you always add it next to **Core** or **Bundle**:
+A module for creating a [Data Sheet](../Data_Sheet/Overview) - an interactive data grid. Unlike the other modules, it is not a part of **Bundle**, so you always add it next to **Core** or **Bundle**:
 
 ```
 <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-data-sheet.min.js"></script>
@@ -482,6 +474,20 @@ The UI Binding module is a set of utilities for binding HTML5 UI elements to cha
 
 ```
 <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-ui-binding.min.js"></script>
+```
+
+### Boost WebGL Renderer
+
+A module that enables the WebGL renderer for [Performance Boost](../Common_Settings/Performance_Boost). Canvas-based boost is part of the main bundle and needs no extra module; this one is only for the heaviest datasets.
+
+```
+<script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-boost-webgl.min.js"></script>
+```
+
+It can also be loaded on demand, in which case boost falls back to Canvas until it resolves:
+
+```
+anychart.loadModule("boost-webgl");
 ```
 
 ### VML Renderer 

--- a/samples/CS_Boost_01.html
+++ b/samples/CS_Boost_01.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="UTF-8">
+    <meta name="ac:name" content="CS Boost 01"/>
+    <meta name="ac:short-desc" content=""/>
+    <meta name="ac:desc" content=""/>
+
+    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-base.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-ui.min.js"></script>
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/{{branch-name}}/css/anychart-ui.min.css" />
+
+    <style>
+        html, body, #container {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+<div id="container"></div>
+<script>
+anychart.onDocumentReady(function () {
+    // 20000 points: well past the 1500-point default, so decimation is doing the work here.
+    var data = [];
+    for (var i = 0; i < 20000; i++) {
+        data.push([i, Math.sin(i / 400) * 50 + Math.sin(i / 37) * 8]);
+    }
+
+    var chart = anychart.line(data);
+    chart.title("Decimation: 20000 points drawn as 2000");
+
+    // Draw at most 2000 points per series instead of the default 1500.
+    chart.maxPointsRendered(2000);
+
+    // "lttb" keeps the points that define the curve's silhouette. Try "min-max" to keep the
+    // envelope instead - the spikes survive, the shape is blockier.
+    chart.decimationAlgorithm("lttb");
+
+    chart.container("container");
+    chart.draw();
+});
+</script>
+</body>
+</html>

--- a/samples/CS_Boost_01.html
+++ b/samples/CS_Boost_01.html
@@ -5,10 +5,7 @@
     <meta name="ac:short-desc" content=""/>
     <meta name="ac:desc" content=""/>
 
-    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-base.min.js"></script>
-    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-ui.min.js"></script>
-
-    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/{{branch-name}}/css/anychart-ui.min.css" />
+    <script src="https://cdn.anychart.com/releases/staging/js/anychart-bundle.min.js"></script>
 
     <style>
         html, body, #container {
@@ -31,6 +28,10 @@ anychart.onDocumentReady(function () {
 
     var chart = anychart.line(data);
     chart.title("Decimation: 20000 points drawn as 2000");
+
+    // 20000 points is past the 5000-point boost threshold, and a boosted series is never
+    // decimated - so boost has to be off for decimation to be the thing on screen.
+    chart.boostEnabled(false);
 
     // Draw at most 2000 points per series instead of the default 1500.
     chart.maxPointsRendered(2000);

--- a/samples/CS_Boost_02.html
+++ b/samples/CS_Boost_02.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="UTF-8">
+    <meta name="ac:name" content="CS Boost 02"/>
+    <meta name="ac:short-desc" content=""/>
+    <meta name="ac:desc" content=""/>
+
+    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-base.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-ui.min.js"></script>
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/{{branch-name}}/css/anychart-ui.min.css" />
+
+    <style>
+        html, body, #container {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+<div id="container"></div>
+<script>
+anychart.onDocumentReady(function () {
+    var data = [];
+    for (var i = 0; i < 40000; i++) {
+        data.push([i, Math.sin(i / 900) * 40 + Math.sin(i / 23) * 6]);
+    }
+
+    var chart = anychart.line(data);
+    chart.title("Boost: one Canvas layer instead of 40000 SVG elements");
+
+    // Force boost rather than waiting for the 5000-point threshold, so the sample shows the
+    // Canvas path even if the data is trimmed. Set it to false to compare against plain SVG.
+    chart.boostEnabled(true);
+
+    // Boost draws every point, so decimation is skipped while it is active.
+    chart.container("container");
+    chart.draw();
+});
+</script>
+</body>
+</html>

--- a/samples/CS_Boost_02.html
+++ b/samples/CS_Boost_02.html
@@ -21,17 +21,17 @@
 <script>
 anychart.onDocumentReady(function () {
     var data = [];
-    for (var i = 0; i < 40000; i++) {
+    for (var i = 0; i < 10000; i++) {
         data.push([i, Math.sin(i / 900) * 40 + Math.sin(i / 23) * 6]);
     }
 
     var chart = anychart.marker(data);
-    chart.title("Boost: one Canvas layer instead of 40000 SVG elements");
+    chart.title("Boost: one Canvas layer instead of 10000 SVG elements");
 
     // A marker series is one of the shapes the Canvas renderer draws faithfully. Line and area
     // series are not - the renderer fills a line down to the zero line, and skips area series
     // altogether - so this sample uses markers.
-    // 40000 points is past the 5000-point threshold, so boost would engage on its own here;
+    // 10000 points is past the 5000-point threshold, so boost would engage on its own here;
     // setting it explicitly makes the switch visible. Set it to false to compare against SVG -
     // decimation is no longer pre-empted then, and trims the series to the default 1500 points.
     chart.boostEnabled(true);

--- a/samples/CS_Boost_02.html
+++ b/samples/CS_Boost_02.html
@@ -25,12 +25,15 @@ anychart.onDocumentReady(function () {
         data.push([i, Math.sin(i / 900) * 40 + Math.sin(i / 23) * 6]);
     }
 
-    var chart = anychart.line(data);
+    var chart = anychart.marker(data);
     chart.title("Boost: one Canvas layer instead of 40000 SVG elements");
 
+    // A marker series is one of the shapes the Canvas renderer draws faithfully. Line and area
+    // series are not - the renderer fills a line down to the zero line, and skips area series
+    // altogether - so this sample uses markers.
     // 40000 points is past the 5000-point threshold, so boost would engage on its own here;
     // setting it explicitly makes the switch visible. Set it to false to compare against SVG -
-    // decimation is no longer pre-empted then, and trims the line to the default 1500 points.
+    // decimation is no longer pre-empted then, and trims the series to the default 1500 points.
     chart.boostEnabled(true);
 
     // Boost draws every point, so decimation is skipped while it is active.

--- a/samples/CS_Boost_02.html
+++ b/samples/CS_Boost_02.html
@@ -5,10 +5,7 @@
     <meta name="ac:short-desc" content=""/>
     <meta name="ac:desc" content=""/>
 
-    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-base.min.js"></script>
-    <script src="https://cdn.anychart.com/releases/{{branch-name}}/js/anychart-ui.min.js"></script>
-
-    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/{{branch-name}}/css/anychart-ui.min.css" />
+    <script src="https://cdn.anychart.com/releases/staging/js/anychart-bundle.min.js"></script>
 
     <style>
         html, body, #container {
@@ -31,8 +28,9 @@ anychart.onDocumentReady(function () {
     var chart = anychart.line(data);
     chart.title("Boost: one Canvas layer instead of 40000 SVG elements");
 
-    // Force boost rather than waiting for the 5000-point threshold, so the sample shows the
-    // Canvas path even if the data is trimmed. Set it to false to compare against plain SVG.
+    // 40000 points is past the 5000-point threshold, so boost would engage on its own here;
+    // setting it explicitly makes the switch visible. Set it to false to compare against SVG -
+    // decimation is no longer pre-empted then, and trims the line to the default 1500 points.
     chart.boostEnabled(true);
 
     // Boost draws every point, so decimation is skipped while it is active.


### PR DESCRIPTION
## Summary

Corrects the boost and decimation article against what the v9 engine actually does. Every claim in it was re-checked by rendering the described configuration on the staging bundle (9.0.0.2423) rather than by reading the source — which is how the errors below were found.

Refs A9-462.

## What was wrong, and how it was verified

- **Chart types listed as boosting that do not.** Area, heatmap and box were documented as boost-capable. Measured: area and heatmap render an empty canvas with boost on, box renders blank. Filed as A9-610 (Critical) — the engine decides to boost before checking whether the drawer supports it.
- **Stock decimation described as working per series.** Series-level decimation is inert on stock; `boostEnabled` does work. Corrected to say so.
- **Missing types.** `jumpLine` and `stick` boost and were absent; `streamGraph` was absent from the supported list.
- **Skip conditions were headed "in automatic mode"** for conditions that apply in every mode.
- **A self-contradiction** claiming the two mechanisms are independent, in an article that elsewhere describes them interacting.
- **Four dead `{api:}` links** to a class with no reference page.

## Change set

- `Common_Settings/Performance_Boost.md` — the corrections above.
- Samples repinned to `releases/staging` so they exercise the v9 bundle rather than a stale one.
- `CS_Boost_01` gained an explicit `boostEnabled(false)` arm so the article shows the contrast it describes.
- `CS_Boost_02` switched to `anychart.marker`, a type that actually boosts.

## Reviewer notes

The article deliberately does **not** document boost on heatmap, waterfall, streamGraph or timeline. Those surfaces were measured and found inert or broken; documenting them would promise behaviour the engine does not deliver. The corresponding library-side defect is tracked in A9-610.

The API reference half of this ticket is a separate PR in `api.anychart.com`, and the library-side enum plus typings are a third PR in `AnyChart-9`.
